### PR TITLE
Broke down empty mesh initialization check with loop

### DIFF
--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -3,6 +3,7 @@ from pyne.material import Material, MaterialLibrary, MultiMaterial
 import sys
 import copy
 import itertools
+import inspect
 from collections import Iterable, Sequence
 from warnings import warn
 from pyne.utils import QAWarning
@@ -704,9 +705,18 @@ class Mesh(object):
             stored in self.dims.
 
         """
+        # obtain param names and default values
+        args, _, _, defaults = inspect.getargspec(Mesh.__init__)
+
+        #check if param values are all default, indicating empty initialization
+        allDefault = True
+        for arg, default in zip(args[1:], defaults):
+            if eval(arg) != default:
+                allDefault = False
+                break
+
         # if Mesh is made and no parameters passed, raise MeshError
-        if mesh is None and not structured and structured_coords is None and \
-            structured_set is None and structured_ordering=='xyz' and mats==():
+        if allDefault:
             raise MeshError("Trivial mesh instantiation "
                             "For structured mesh instantiation, need to "
                                 "supply exactly one of the following:\n"

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -707,13 +707,9 @@ class Mesh(object):
         """
         # obtain param names and default values
         args, _, _, defaults = inspect.getargspec(Mesh.__init__)
-
-        #check if param values are all default, indicating empty initialization
-        allDefault = True
-        for arg, default in zip(args[1:], defaults):
-            if eval(arg) != default:
-                allDefault = False
-                break
+        #create tuple of param values using list comprehension
+        args = tuple([eval(arg) for arg in args[1:]])
+        allDefault = args == defaults
 
         # if Mesh is made and no parameters passed, raise MeshError
         if allDefault:


### PR DESCRIPTION
This fix should address the comment from @pshriwise in #1141 about the conditional for the default initializer being too lengthy. Instead of defining a tuple of the default values, this change alternatively obtains the names of the arguments and their default values using 'inspect.getargspec()'.